### PR TITLE
Fix null pointer exception in FormHandler.js

### DIFF
--- a/server/FormHandler.js
+++ b/server/FormHandler.js
@@ -1,5 +1,9 @@
 function handleSave(data) {
-  console.log(data.field.length); // 🐛 potential null pointer
+  if (data && data.field && data.field.length !== undefined) {
+    console.log(data.field.length);
+  } else {
+    console.log('Field data is null or undefined');
+  }
 }
 
 module.exports = { handleSave };


### PR DESCRIPTION
This PR fixes a null pointer exception in FormHandler.js by adding proper null checks before accessing data.field.length.

**Changes made:**
- Added null checks for `data` and `data.field` before accessing length property
- Added else condition to log appropriate message when field data is null or undefined
- Prevents potential runtime crash when data.field is null

**Issue:** The original code accessed `data.field.length` without checking if `data.field` was null or undefined, causing a null pointer exception.

**Solution:** Added proper validation to ensure the field exists before accessing its properties.