### PR TITLE
fix: prevent crash when field is null in handleSave

### DIFF
--- a/server/FormHandler.js
+++ b/server/FormHandler.js
@@ -1,8 +1,8 @@
 function handleSave(data) {
-  if (data && data.field != null) {
+  if (data && data.field && typeof data.field.length === 'number') {
     console.log(data.field.length);
   } else {
-    console.log('field is missing');
+    console.log('Invalid input: field is missing or not countable');
   }
 }
 

--- a/server/FormHandler.js
+++ b/server/FormHandler.js
@@ -1,9 +1,8 @@
 function handleSave(data) {
-  // Add null/undefined checks to prevent null pointer exception
-  if (data && data.field && typeof data.field.length !== 'undefined') {
+  if (data && data.field != null) {
     console.log(data.field.length);
   } else {
-    console.log('Invalid data: field is null, undefined, or missing length property');
+    console.log('field is missing');
   }
 }
 

--- a/server/FormHandler.js
+++ b/server/FormHandler.js
@@ -1,9 +1,9 @@
 function handleSave(data) {
-  // Add null check to prevent crash
-  if (data && data.field && data.field.length !== undefined) {
+  // Add null checks to prevent crashes
+  if (data && data.field && typeof data.field.length !== 'undefined') {
     console.log(data.field.length);
   } else {
-    console.log('No field data provided or field is empty');
+    console.log('Invalid or missing field data');
   }
 }
 

--- a/server/FormHandler.js
+++ b/server/FormHandler.js
@@ -1,9 +1,9 @@
 function handleSave(data) {
-  // Add null checks to prevent crashes
+  // Add null/undefined checks to prevent null pointer exception
   if (data && data.field && typeof data.field.length !== 'undefined') {
     console.log(data.field.length);
   } else {
-    console.log('Invalid or missing field data');
+    console.log('Invalid data: field is null, undefined, or missing length property');
   }
 }
 

--- a/server/FormHandler.js
+++ b/server/FormHandler.js
@@ -1,5 +1,10 @@
 function handleSave(data) {
-  console.log(data.field.length); // 🐛 potential null pointer
+  // Add null check to prevent crash
+  if (data && data.field && data.field.length !== undefined) {
+    console.log(data.field.length);
+  } else {
+    console.log('No field data provided or field is empty');
+  }
 }
 
 module.exports = { handleSave };


### PR DESCRIPTION
This PR fixes a potential null pointer exception in `server/FormHandler.js` where accessing `data.field.length` could crash if `data.field` is null or undefined. Now, it checks for existence and type before accessing `.length`.

Fixed by engineer leilatrend (Leila Kao).