### PR TITLE
fix(server): add null/array check to prevent crash on data.field in handleSave

### DIFF
--- a/server/FormHandler.js
+++ b/server/FormHandler.js
@@ -1,5 +1,9 @@
 function handleSave(data) {
-  console.log(data.field.length); // 🐛 potential null pointer
+  if (data && Array.isArray(data.field)) {
+    console.log(data.field.length);
+  } else {
+    console.log('field is missing or not an array');
+  }
 }
 
 module.exports = { handleSave };


### PR DESCRIPTION
## Bug Fix Summary
App crashed when `data.field` was `null` or `undefined` due to direct access of `.length`.
This PR adds a null and array-type check before accessing `data.field.length` to prevent runtime crashes.

---

### Issue Analysis

- **Affected file:** `server/FormHandler.js`
- **Description:** App crashed if `data.field` is null/undefined because `.length` was accessed directly.
- **Root cause:** No guard before using `.length` property on potentially null/undefined field (introduced in initial commit).
- **Line number:** 2

### Changes Made
- Added: `if (data && Array.isArray(data.field))` guard before logging length.
- Fallback: Log message if `field` is missing or not an array.

### Testing
- Manually tested with valid array, null, undefined, and non-array types for `data.field`. No crash observed and correct log output for invalid input.

### Code Changes
**Before:**
```js
function handleSave(data) {
  console.log(data.field.length); // 🐛 potential null pointer
}
```

**After:**
```js
function handleSave(data) {
  if (data && Array.isArray(data.field)) {
    console.log(data.field.length);
  } else {
    console.log('field is missing or not an array');
  }
}
```