### PR TITLE
fix: add null/undefined check for data.field in handleSave

### DIFF
--- a/server/FormHandler.js
+++ b/server/FormHandler.js
@@ -1,5 +1,9 @@
 function handleSave(data) {
-  console.log(data.field.length); // 🐛 potential null pointer
+  if (data.field) {
+    console.log(data.field.length);
+  } else {
+    console.log('No field value provided');
+  }
 }
 
 module.exports = { handleSave };


### PR DESCRIPTION
### Bug Fix Summary
This PR fixes a potential runtime error in `handleSave` where accessing `data.field.length` could throw if `data.field` is null or undefined. The impact is that invalid or missing input could crash the handler with a TypeError.

---

### Issue Analysis
- **Affected file(s) and path(s):** `server/FormHandler.js`
- **Specific line number(s) related to the issue:** Line 2 (the line accessing `data.field.length`)
- **Description of the problem and triggering condition:** When `data.field` is missing or null, `data.field.length` throws.
- **Root cause of the issue:** Recent code (commit `f28f5531`) introduced direct dereference of `data.field` without a null check.

---

### Changes Made
- Added a null/undefined check before accessing `data.field.length`.
- Added a fallback log message if the field is missing.

---

### Testing
- Simulated cases with `data.field` as a string (logs length), as null or undefined (logs fallback message).
- Ensures no crash and valid output.

---

### Code Changes
```diff
-function handleSave(data) {
-  console.log(data.field.length); // 🐛 potential null pointer
-}
+function handleSave(data) {
+  if (data.field) {
+    console.log(data.field.length);
+  } else {
+    console.log('No field value provided');
+  }
+}
```
---

This prevents crashes for missing fields and safely logs the outcome.