### PR TITLE
fix: add null check to FormHandler to prevent null pointer crash

### DIFF
--- a/server/FormHandler.js
+++ b/server/FormHandler.js
@@ -1,5 +1,9 @@
 function handleSave(data) {
-  console.log(data.field.length); // 🐛 potential null pointer
+  if (data && data.field) {
+    console.log(data.field.length);
+  } else {
+    console.error("Field data is missing or null", data);
+  }
 }
 
 module.exports = { handleSave };


### PR DESCRIPTION
## Bug Fix Summary
This PR fixes a null pointer exception that occurs when saving form data if `data.field` is undefined or null. Now, the function gracefully logs an error instead of crashing.

---

### Issue Analysis

- **Affected File:** `server/FormHandler.js`
- **Relevant Commit:** f28f5531eef9e05fd3b276ae6ea882ef72781990 (removed null check)
- **Line Number:** `console.log(data.field.length);`
- **Root Cause:** Lack of a null/undefined check for `data.field`.

### Changes Made
- Added an if check for `data && data.field` before logging `data.field.length`.
- Added error logging if the data or field is missing.

### Testing
- Tested saving data with a valid field array — logs the length as expected.
- Tested saving with missing/null field — now logs an error rather than throwing an exception.

### Code Changes
Before:
```js
function handleSave(data) {
  console.log(data.field.length); // 🐛 potential null pointer
}
```
After:
```js
function handleSave(data) {
  if (data && data.field) {
    console.log(data.field.length);
  } else {
    console.error("Field data is missing or null", data);
  }
}
```
