### PR TITLE
fix: add null check in FormHandler to prevent crash on missing field data

### DIFF
--- a/server/FormHandler.js
+++ b/server/FormHandler.js
@@ -1,5 +1,9 @@
 function handleSave(data) {
-  console.log(data.field.length); // 🐛 potential null pointer
+  if (data.field && Array.isArray(data.field)) {
+    console.log(data.field.length);
+  } else {
+    console.log('Field is missing or not an array');
+  }
 }
 
 module.exports = { handleSave };


### PR DESCRIPTION
## Bug Fix Summary
This PR fixes a runtime crash in `server/FormHandler.js` when saving form data with a missing `field` property. The bug previously caused a null pointer exception if `data.field` was null or undefined.

---

### Issue Analysis
- **Affected file(s) and path(s):** `server/FormHandler.js`
- **Specific line number(s):** Access to `data.field.length`.
- **Problem:** Accessing `length` on a potentially null field crashed the handler.
- **Root Cause:** Commit `f28f553` (`feat: save form data without null check`) omitted a null check.

---

## Changes Made
- Added null and type check for `data.field` before accessing `.length`.
- Added logging to inform when field is invalid.

---

## Testing
- Manual tests with valid, null, and undefined `data.field` confirm safe handling—no exceptions are thrown and an error is logged as expected.

---

### Code Changes
**Before:**
```js
function handleSave(data) {
  console.log(data.field.length); // 🐛 potential null pointer
}
```
**After:**
```js
function handleSave(data) {
  if (data.field && Array.isArray(data.field)) {
    console.log(data.field.length);
  } else {
    console.log('Field is missing or not an array');
  }
}
```