### PR TITLE
fix: prevent crash if field is null in handleSave

### DIFF
--- a/server/FormHandler.js
+++ b/server/FormHandler.js
@@ -1,5 +1,9 @@
 function handleSave(data) {
-  console.log(data.field.length); // 🐛 potential null pointer
+  if (!data.field) {
+    console.error('Field is missing in data:', data);
+    return;
+  }
+  console.log(data.field.length);
 }
 
 module.exports = { handleSave };


### PR DESCRIPTION
## Bug Fix Summary

This PR fixes a crash that occurred if `data.field` was `null` or `undefined` when calling the `handleSave` function in `server/FormHandler.js`. By adding a null check before accessing `.length`, we prevent server errors and improve stability when saving forms with missing fields.

---

**Issue Analysis:**
- **Affected file(s) and path(s):** `server/FormHandler.js`
- **Specific line(s):** 2
- **Problem:** `data.field.length` could throw if `field` is null/undefined
- **Root cause:** Earlier code (commit f28f553) added save logic without handling missing/null fields.

**Changes Made:**
- Added a guard clause to exit early & log an error if `data.field` is falsy (null/undefined)
- Added error logging

**Testing:**
- Manually tested: saving form with missing/undefined field no longer crashes server; error log is output and flow returns cleanly.

---

**Code Changes:**
<details><summary>Before</summary>

```js
function handleSave(data) {
  console.log(data.field.length); // 🧐 potential null pointer
}
```
</details>

<details><summary>After</summary>

```js
function handleSave(data) {
  if (!data.field) {
    console.error('Field is missing in data:', data);
    return;
  }
  console.log(data.field.length);
}
```
</details>
