### PR TITLE
fix: add null check to prevent crash if field is null in handleSave

### DIFF
--- a/server/FormHandler.js
+++ b/server/FormHandler.js
@@ -1,5 +1,9 @@
 function handleSave(data) {
-  console.log(data.field.length); // 🐛 potential null pointer
+  if (!data || !data.field) {
+    console.error("Invalid form data:", data);
+    return;
+  }
+  console.log(data.field.length);
 }
 
 module.exports = { handleSave };


### PR DESCRIPTION
## Bug Fix Summary

This PR adds a null check to the `handleSave` function in `server/FormHandler.js`, preventing a crash when `data` or `data.field` is undefined/null. This bug could cause the server to throw and terminate, affecting user experience when malformed form data is submitted.

---

### Issue Analysis

- **Affected file(s) and path(s):**
  - `server/FormHandler.js`
- **Specific line number(s) related to the issue:**
  - Line with `console.log(data.field.length);`
- **Description of the problem and triggering condition:**
  - If `data` is null/undefined or if `data.field` is missing, a runtime error occurs.
- **Root cause of the issue:**
  - Commit: f28f5531 (feat: save form data without null check)

### Changes Made
- Added a guard clause: `if (!data || !data.field)` with an error log and early return.

### Testing
- Manually tested `handleSave()` with undefined/null/invalid/valid data objects. Confirmed the function logs an error (instead of throwing) when inappropriate data is supplied, and logs length only when valid.

### Code Changes
**Before:**
```js
function handleSave(data) {
  console.log(data.field.length); // 🐛 potential null pointer
}
```

**After:**
```js
function handleSave(data) {
  if (!data || !data.field) {
    console.error("Invalid form data:", data);
    return;
  }
  console.log(data.field.length);
}
```

---
This fix ensures robust error handling and prevents server crashes from poorly structured input.
