### PR TITLE
fix: prevent null pointer on form save

### DIFF
--- a/server/FormHandler.js
+++ b/server/FormHandler.js
@@ -1,5 +1,5 @@
 function handleSave(data) {
-  console.log(data.field.length); // 🐛 potential null pointer
+  const fieldLen = (data && data.field) ? data.field.length : 0;
+  console.log(fieldLen); // 🐋 safe now!
 }
-
 module.exports = { handleSave };


### PR DESCRIPTION
## Bug Fix Summary

### Issue Analysis
- **Affected file(s) and path(s):** `server/FormHandler.js`
- **Specific line(s):** 2
- **Description:** Potential null pointer due to `data.field` possibly being null or undefined; would crash when accessing `.length`.
- **Root cause:** No null or undefined check was performed on `data.field` (see recent commits for initial handler intro).

### Changes Made
- Added null/undefined check before accessing `.length` of `data.field`.
- Sets length to 0 if `data.field` is missing.

### Testing
- Tested with missing `field` property (no crash, logs '0').
- Tested with populated `field` property (logs correct length).

### Code Changes
**Before:**
```js
function handleSave(data) {
  console.log(data.field.length); // 🐋 potential null pointer
}
```
**After:**
```js
function handleSave(data) {
  const fieldLen = (data && data.field) ? data.field.length : 0;
  console.log(fieldLen); // 🐋 safe now!
}
```

---

This fix prevents null pointer exceptions in form save handler.