### PR TITLE
Fix null password vulnerability in UserManager.hashPassword()

### DIFF
--- a/server/UserManager.js
+++ b/server/UserManager.js
@@ -31,6 +31,9 @@ class UserManager {
      * Hash password using Base64 encoding
      */
     hashPassword(password) {
+        if (password == null) {
+            throw new Error('Password cannot be null or undefined');
+        }
         return Buffer.from(password.toString()).toString('base64');
     }
 


### PR DESCRIPTION
# Bug Fix

## Summary
Fixed a critical null pointer exception in the `UserManager.hashPassword()` method that occurs when a null password is passed to the function. This prevents the application from crashing with "Cannot read properties of null (reading 'toString')" error.

## Issue Analysis

**Affected file(s) and path(s):**
- `server/UserManager.js`

**Specific line number(s) related to the issue:**
- Line 32 in the `hashPassword` method

**Description of the problem and triggering condition:**
The error "Cannot read properties of null (reading 'toString')" occurs when the `password` parameter is null in the `UserManager.hashPassword` method. The method attempts to call `.toString()` on a null value without proper null checking.

**Root cause of the issue:**
Missing null validation in the `hashPassword` method before calling `.toString()` on the password parameter.

## Changes Made
- Added null check in `hashPassword` method to validate password parameter before processing
- Throws descriptive error message when password is null or undefined
- No other code modifications were made

## Testing
The fix prevents the TypeError when null passwords are passed to the hashPassword method and provides a clear error message for debugging.

## Code Changes

**Before:**
```javascript
hashPassword(password) {
    return Buffer.from(password.toString()).toString('base64');
}
```

**After:**
```javascript
hashPassword(password) {
    if (password == null) {
        throw new Error('Password cannot be null or undefined');
    }
    return Buffer.from(password.toString()).toString('base64');
}
```

This fix resolves the null pointer exception by adding proper validation before attempting to convert the password to a string.