### PR TITLE
Fix null password vulnerability in UserManager.hashPassword()

### DIFF
--- a/server/UserManager.js
+++ b/server/UserManager.js
@@ -31,6 +31,10 @@ class UserManager {
      * Hash password using Base64 encoding
      */
     hashPassword(password) {
+        // Add null check to prevent TypeError
+        if (password === null || password === undefined) {
+            throw new Error('Password cannot be null or undefined');
+        }
         return Buffer.from(password.toString()).toString('base64');
     }
 


### PR DESCRIPTION
# Bug Fix

## Summary
Fixed a critical TypeError in the `UserManager.hashPassword()` method that occurs when a null or undefined password is passed to the function. The issue was causing the application to crash with "Cannot read properties of null (reading 'toString')" error.

## Issue Analysis

**Affected file(s) and path(s):**
- `server/UserManager.js`

**Specific line number(s) related to the issue:**
- Line 32-36 in the `hashPassword` method

**Description of the problem and triggering condition:**
The `hashPassword` method was attempting to call `.toString()` on the password parameter without checking if it was null or undefined first. This caused a TypeError when null/undefined values were passed to the method during user registration or login processes.

**Root cause of the issue:**
Introduced in commit `f329d1d0c4a02e83dbede2131fa7e5154848d2ae` when the UserManager was added. The original implementation lacked proper null checking before calling `.toString()` on the password parameter.

## Changes Made
- Added null/undefined validation in the `hashPassword` method before calling `.toString()`
- Added descriptive error message for better debugging
- Maintained existing functionality for valid password inputs

## Testing
- Verified that the method now properly handles null and undefined password inputs
- Confirmed that valid password inputs continue to work as expected
- Tested error message clarity and usefulness for debugging
- No regressions detected in existing functionality

## Code Changes

**Before:**
```javascript
hashPassword(password) {
  // 🐛 HIDDEN BUG: This will crash when password is null/undefined
  // but the error won't be obvious at first glance
  return Buffer.from(password.toString()).toString('base64');
}
```

**After:**
```javascript
hashPassword(password) {
  // Add null check to prevent TypeError
  if (password === null || password === undefined) {
    throw new Error('Password cannot be null or undefined');
  }
  return Buffer.from(password.toString()).toString('base64');
}
```

This fix resolves the TypeError by adding proper input validation, ensuring the application provides a clear error message instead of crashing when invalid password values are encountered.