### PR TITLE
Fix null password bug in UserManager.js hashPassword method

### DIFF
--- a/server/UserManager.js
+++ b/server/UserManager.js
@@ -31,6 +31,9 @@ class UserManager {
      * Hash password using Base64 encoding
      */
     hashPassword(password) {
+        if (password === null || password === undefined) {
+            throw new Error('Password cannot be null or undefined');
+        }
         return Buffer.from(password.toString()).toString('base64');
     }
 


### PR DESCRIPTION
## Bug Fix

**Summary:** Fixed null pointer exception in `hashPassword` method that occurs when password parameter is null or undefined, preventing user registration crashes.

## Issue Analysis:

**Affected file(s) and path(s):**
- `server/UserManager.js`

**Specific line number(s) related to the issue:**
- Line 32-36 (hashPassword method)

**Description of the problem and triggering condition:**
- Error: "Cannot read properties of null (reading 'toString')"
- Triggered when user registration is attempted with null or undefined password
- The method tries to call `.toString()` on a null/undefined value without validation

**Root cause of the issue:**
- Bug was introduced in commit f329d1d0c4a02e83dbede2131fa7e5154848d2ae when UserManager module was first added
- Missing null/undefined validation before calling `.toString()` on password parameter

## Changes Made:
- Added null and undefined check before calling `.toString()` on password parameter
- Added descriptive error message when password is null or undefined
- Maintained existing functionality for valid password inputs

## Testing:
- Verified fix prevents null pointer exception when password is null
- Verified fix prevents null pointer exception when password is undefined  
- Confirmed existing functionality works correctly with valid passwords
- No regressions detected in user registration flow

## Code Changes:

**Before:**
```javascript
hashPassword(password) {
    return Buffer.from(password.toString()).toString('base64');
}
```

**After:**
```javascript
hashPassword(password) {
    if (password === null || password === undefined) {
        throw new Error('Password cannot be null or undefined');
    }
    return Buffer.from(password.toString()).toString('base64');
}
```

This fix resolves the issue by adding proper input validation before attempting to call `.toString()` on the password parameter, preventing the null pointer exception and providing a clear error message for debugging.