### PR TITLE
Fix null pointer exception in UserManager hashPassword method

### DIFF
--- a/server/UserManager.js
+++ b/server/UserManager.js
@@ -31,6 +31,9 @@ class UserManager {
      * Hash password using Base64 encoding
      */
     hashPassword(password) {
+        if (password === null || password === undefined) {
+            throw new Error('Password cannot be null or undefined');
+        }
         return Buffer.from(password.toString()).toString('base64');
     }
 


### PR DESCRIPTION
# Bug Fix

## Summary
Fixed a critical null pointer exception in the `UserManager.hashPassword()` method that was causing crashes during user registration when a null or undefined password was passed.

## Issue Analysis

**Affected file(s) and path(s):**
- `server/UserManager.js`

**Specific line number(s) related to the issue:**
- Line 35 in the `hashPassword` method

**Description of the problem and triggering condition:**
The application was throwing a `Cannot read properties of null (reading 'toString')` error when the `hashPassword` method received a null or undefined password parameter. This occurred during user registration when validation failed to catch null password values before they reached the hashing function.

**Root cause of the issue:**
Commit `f329d1d0c4a02e83dbede2131fa7e5154848d2ae` introduced the `hashPassword` method without proper null/undefined validation before calling `password.toString()`.

## Changes Made
- Added null and undefined checks in the `hashPassword` method
- Added descriptive error message when password is null or undefined
- Maintained existing functionality for valid password inputs

## Testing
The fix prevents the null pointer exception while maintaining the original Base64 password hashing functionality for valid inputs. Error handling now provides clear feedback when invalid password values are passed.

## Code Changes

**Before:**
```javascript
hashPassword(password) {
    return Buffer.from(password.toString()).toString('base64');
}
```

**After:**
```javascript
hashPassword(password) {
    if (password === null || password === undefined) {
        throw new Error('Password cannot be null or undefined');
    }
    return Buffer.from(password.toString()).toString('base64');
}
```

This fix resolves the issue by validating the password parameter before attempting to call `toString()` on it, preventing the null pointer exception and providing clear error messaging for debugging.