### PR TITLE
Fix null/undefined password bug in hashPassword method

### DIFF
--- a/server/UserManager.js
+++ b/server/UserManager.js
@@ -31,6 +31,10 @@ class UserManager {
      * Hash password using Base64 encoding
      */
     hashPassword(password) {
+        // Add null/undefined check before calling toString()
+        if (password === null || password === undefined) {
+            throw new Error('Password cannot be null or undefined');
+        }
         return Buffer.from(password.toString()).toString('base64');
     }
 


### PR DESCRIPTION
# Bug Fix

## Summary
Fixed critical TypeError in `hashPassword` method that occurs when password is null or undefined. The bug causes the application to crash with "Cannot read properties of null (reading 'toString')" error during user registration.

## Issue Analysis

**Affected file(s) and path(s):**
- `server/UserManager.js`

**Specific line number(s) related to the issue:**
- Line 32 in the `hashPassword` method

**Description of the problem and triggering condition:**
The `hashPassword` method attempts to call `toString()` on the password parameter without checking if it's null or undefined. This causes a TypeError when:
- Password validation fails and null is passed
- Undefined password values are processed
- Edge cases in user registration flow

**Root cause of the issue:**
- **Commit SHA:** `f329d1d0c4a02e83dbede2131fa7e5154848d2ae`
- **Commit Message:** "feat: Add user management system with authentication"

## Changes Made
- Added null/undefined check before calling `toString()` on password parameter
- Added proper error handling with descriptive error message
- No other code modifications or improvements made

## Testing
- Verified the fix handles null password values gracefully
- Confirmed undefined password values throw appropriate error
- Tested normal password hashing functionality remains intact
- No regressions in existing user registration flow

## Code Changes

**Before:**
```javascript
hashPassword(password) {
  return Buffer.from(password.toString()).toString('base64');
}
```

**After:**
```javascript
hashPassword(password) {
  // Add null/undefined check before calling toString()
  if (password === null || password === undefined) {
    throw new Error('Password cannot be null or undefined');
  }
  return Buffer.from(password.toString()).toString('base64');
}
```

This fix resolves the TypeError by validating the password parameter before attempting to call `toString()`, providing a clear error message when invalid values are encountered.